### PR TITLE
Add single account Cloud-Bench module

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Note that:
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.50.0 |
+| <a name="requirement_sysdig"></a> [sysdig](#requirement\_sysdig) | >= 0.5.17 |
 
 ## Providers
 
@@ -77,6 +78,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_cloud_bench"></a> [cloud\_bench](#module\_cloud\_bench) | ./modules/services/cloud-bench |  |
 | <a name="module_cloud_connector"></a> [cloud\_connector](#module\_cloud\_connector) | ./modules/services/cloud-connector |  |
 | <a name="module_cloudtrail"></a> [cloudtrail](#module\_cloudtrail) | ./modules/infrastructure/cloudtrail |  |
 | <a name="module_ecs_fargate_cluster"></a> [ecs\_fargate\_cluster](#module\_ecs\_fargate\_cluster) | ./modules/infrastructure/ecs-fargate-cluster |  |

--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ Note that:
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.50.0 |
 
 ## Modules
 
@@ -87,7 +89,9 @@ No providers.
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [aws_caller_identity.me](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -31,6 +31,11 @@ module "cloudtrail" {
 # with cloudvision provider, which can be master or member config
 #-------------------------------------
 
+provider "sysdig" {
+  sysdig_secure_url       = var.sysdig_secure_endpoint
+  sysdig_secure_api_token = var.sysdig_secure_api_token
+}
+
 module "ecs_fargate_cluster" {
   providers = {
     aws = aws.cloudvision
@@ -78,6 +83,17 @@ module "cloud_connector" {
   depends_on = [module.cloudtrail, module.ecs_fargate_cluster, module.ssm]
 }
 
+module "cloud_bench" {
+  providers = {
+    aws = aws.member
+  }
+  source = "./modules/services/cloud-bench"
+
+  sysdig_secure_endpoint = var.sysdig_secure_endpoint
+
+  account_id  = var.org_cloudvision_member_account_id
+  tags       = var.tags
+}
 
 
 ## FIXME? if this is a non-shared resource, move its usage to scanning service?

--- a/main.tf
+++ b/main.tf
@@ -89,8 +89,6 @@ module "cloud_bench" {
   }
   source = "./modules/services/cloud-bench"
 
-  sysdig_secure_endpoint = var.sysdig_secure_endpoint
-
   account_id  = var.org_cloudvision_member_account_id
   tags       = var.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,12 @@
+# FIXME. refact verify_ssl so its handled in upper layers and passed downwards
+locals {
+  verify_ssl = length(regexall("https://.*?\\.sysdig(cloud)?.com/?", var.sysdig_secure_endpoint)) == 1 ? false: true
+}
+
 provider "sysdig" {
-  sysdig_secure_url       = var.sysdig_secure_endpoint
-  sysdig_secure_api_token = var.sysdig_secure_api_token
+  sysdig_secure_url           = var.sysdig_secure_endpoint
+  sysdig_secure_api_token     = var.sysdig_secure_api_token
+  sysdig_secure_insecure_tls  = local.verify_ssl
 }
 
 #-------------------------------------
@@ -82,8 +88,11 @@ module "cloud_connector" {
   depends_on = [module.cloudtrail, module.ecs_fargate_cluster, module.ssm]
 }
 
-data "aws_caller_identity" "me" {}
 
+
+
+
+data "aws_caller_identity" "me" {}
 module "cloud_bench" {
   providers = {
     aws = aws.cloudvision
@@ -93,6 +102,8 @@ module "cloud_bench" {
   account_id = var.is_organizational ? var.organizational_config.cloudvision_member_account_id : data.aws_caller_identity.me.account_id
   tags       = var.tags
 }
+
+
 
 
 ## FIXME? if this is a non-shared resource, move its usage to scanning service?

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,7 @@
+provider "sysdig" {
+  sysdig_secure_url       = var.sysdig_secure_endpoint
+  sysdig_secure_api_token = var.sysdig_secure_api_token
+}
 
 #-------------------------------------
 # resources deployed always in master account
@@ -30,11 +34,6 @@ module "cloudtrail" {
 # resources deployed in master OR member account
 # with cloudvision provider, which can be master or member config
 #-------------------------------------
-
-provider "sysdig" {
-  sysdig_secure_url       = var.sysdig_secure_endpoint
-  sysdig_secure_api_token = var.sysdig_secure_api_token
-}
 
 module "ecs_fargate_cluster" {
   providers = {
@@ -85,11 +84,11 @@ module "cloud_connector" {
 
 module "cloud_bench" {
   providers = {
-    aws = aws.member
+    aws = aws.cloudvision
   }
   source = "./modules/services/cloud-bench"
 
-  account_id  = var.org_cloudvision_member_account_id
+  account_id = var.organizational_config.cloudvision_member_account_id
   tags       = var.tags
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,12 +1,12 @@
 # FIXME. refact verify_ssl so its handled in upper layers and passed downwards
 locals {
-  verify_ssl = length(regexall("https://.*?\\.sysdig(cloud)?.com/?", var.sysdig_secure_endpoint)) == 1 ? false: true
+  verify_ssl = length(regexall("https://.*?\\.sysdig(cloud)?.com/?", var.sysdig_secure_endpoint)) == 1 ? false : true
 }
 
 provider "sysdig" {
-  sysdig_secure_url           = var.sysdig_secure_endpoint
-  sysdig_secure_api_token     = var.sysdig_secure_api_token
-  sysdig_secure_insecure_tls  = local.verify_ssl
+  sysdig_secure_url          = var.sysdig_secure_endpoint
+  sysdig_secure_api_token    = var.sysdig_secure_api_token
+  sysdig_secure_insecure_tls = local.verify_ssl
 }
 
 #-------------------------------------

--- a/modules/services/cloud-bench/README.md
+++ b/modules/services/cloud-bench/README.md
@@ -45,11 +45,11 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_iam_role.cloudbench_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.cloudbench_security_audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/aws_iam_role_policy_attachment) | resource |
+| [aws_iam_policy.SecurityAudit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 | [aws_iam_policy_document.trust_relationship](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_role_policy.cloudbench_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
-| [aws_iam_policy_document.permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [sysdig_secure_cloud_account.cloud_account](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/resources/sysdig_secure_cloud_account) | resource |
-| [sysdig_cloud_bench_user.trusted_sysdig_role](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/data-sources/sysdig_cloud_bench_user) | data source |
+| [sysdig_secure_cloud_bench_user.trusted_sysdig_role](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/data-sources/sysdig_secure_cloud_bench_user) | data source |
 
 ## Inputs
 

--- a/modules/services/cloud-bench/README.md
+++ b/modules/services/cloud-bench/README.md
@@ -28,18 +28,22 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_iam_role.cloudbench_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy_attachment.cloudbench_security_audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/aws_iam_role_policy_attachment) | resource |
-| [aws_iam_policy.SecurityAudit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
+| [aws_iam_role_policy_attachment.cloudbench_security_audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [sysdig_secure_cloud_account.cloud_account](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/resources/secure_cloud_account) | resource |
+| [aws_iam_policy.security_audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 | [aws_iam_policy_document.trust_relationship](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [sysdig_secure_cloud_account.cloud_account](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/resources/sysdig_secure_cloud_account) | resource |
-| [sysdig_secure_trusted_cloud_identity.trusted_sysdig_role](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/data-sources/sysdig_secure_trusted_cloud_identity) | data source |
+| [sysdig_secure_trusted_cloud_identity.trusted_sysdig_role](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/data-sources/secure_trusted_cloud_identity) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="account_id"></a> [tags](#input\_account_id) | the account_id in which to provision the cloud-bench IAM role | `string` | `123456789012` | n/a | yes |
+| <a name="input_account_id"></a> [account\_id](#input\_account\_id) | the account\_id in which to provision the cloud-bench IAM role | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | sysdig cloudvision tags | `map(string)` | <pre>{<br>  "product": "sysdig-cloudvision"<br>}</pre> | no |
+
+## Outputs
+
+No outputs.
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/modules/services/cloud-bench/README.md
+++ b/modules/services/cloud-bench/README.md
@@ -2,23 +2,6 @@
 
 Deploys the required IAM Role and IAM Policies to allow Sysdig to run AWS Benchmarks on your behalf.
 
-## Usage
-
-```hcl
-provider "aws" {
-  region = "us-east-1"
-}
-
-provider "sysdig" {
-  sysdig_secure_api_token = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-}
-
-module "cloud_bench_aws" {
-  source = "sysdiglabs/cloudvision/aws/modules/cloudbench"
-
-  account_id = "123456789012"
-}
-```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
@@ -49,7 +32,7 @@ No modules.
 | [aws_iam_policy.SecurityAudit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 | [aws_iam_policy_document.trust_relationship](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [sysdig_secure_cloud_account.cloud_account](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/resources/sysdig_secure_cloud_account) | resource |
-| [sysdig_secure_trusted_cloud_user.trusted_sysdig_role](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/data-sources/sysdig_secure_trusted_cloud_user) | data source |
+| [sysdig_secure_trusted_cloud_identity.trusted_sysdig_role](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/data-sources/sysdig_secure_trusted_cloud_identity) | data source |
 
 ## Inputs
 

--- a/modules/services/cloud-bench/README.md
+++ b/modules/services/cloud-bench/README.md
@@ -1,0 +1,69 @@
+# Cloud Bench deploy in AWS Module
+
+Deploys the required IAM Role and IAM Policies to allow Sysdig to run AWS Benchmarks on your behalf.
+
+## Usage
+
+```hcl
+provider "aws" {
+  region = "us-east-1"
+}
+
+provider "sysdig" {
+  sysdig_secure_api_token = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+}
+
+module "cloud_bench_aws" {
+  source = "sysdiglabs/cloudvision/aws/modules/cloudbench"
+
+  account_id = "123456789012"
+}
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.50.0 |
+| <a name="requirement_sysdig"></a> [sysdig](#requirement\_sysdig) | >= 0.5.17 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.50.0 |
+| <a name="provider_sysdig"></a> [sysdig](#provider\_sysdig) | >= 0.5.17 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_role.cloudbench_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_policy_document.trust_relationship](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_role_policy.cloudbench_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_policy_document.permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [sysdig_secure_cloud_account.cloud_account](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/resources/sysdig_secure_cloud_account) | resource |
+| [sysdig_cloud_bench_user.trusted_sysdig_role](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/data-sources/sysdig_cloud_bench_user) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="account_id"></a> [tags](#input\_account_id) | the account_id in which to provision the cloud-bench IAM role | `string` | `123456789012` | n/a | yes |
+| <a name="input_sysdig_secure_endpoint"></a> [sysdig\_secure\_endpoint](#input\_sysdig\_secure\_endpoint) | Sysdig Secure API endpoint | `string` | `"https://secure.sysdig.com"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | sysdig cloudvision tags | `map(string)` | <pre>{<br>  "product": "sysdig-cloudvision"<br>}</pre> | no |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## Authors
+
+Module is maintained by [Sysdig](https://sysdig.com).
+
+## License
+
+Apache 2 Licensed. See LICENSE for full details.

--- a/modules/services/cloud-bench/README.md
+++ b/modules/services/cloud-bench/README.md
@@ -49,14 +49,13 @@ No modules.
 | [aws_iam_policy.SecurityAudit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 | [aws_iam_policy_document.trust_relationship](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [sysdig_secure_cloud_account.cloud_account](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/resources/sysdig_secure_cloud_account) | resource |
-| [sysdig_secure_cloud_bench_user.trusted_sysdig_role](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/data-sources/sysdig_secure_cloud_bench_user) | data source |
+| [sysdig_secure_trusted_cloud_user.trusted_sysdig_role](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/data-sources/sysdig_secure_trusted_cloud_user) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="account_id"></a> [tags](#input\_account_id) | the account_id in which to provision the cloud-bench IAM role | `string` | `123456789012` | n/a | yes |
-| <a name="input_sysdig_secure_endpoint"></a> [sysdig\_secure\_endpoint](#input\_sysdig\_secure\_endpoint) | Sysdig Secure API endpoint | `string` | `"https://secure.sysdig.com"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | sysdig cloudvision tags | `map(string)` | <pre>{<br>  "product": "sysdig-cloudvision"<br>}</pre> | no |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/modules/services/cloud-bench/main.tf
+++ b/modules/services/cloud-bench/main.tf
@@ -1,0 +1,97 @@
+resource "sysdig_secure_cloud_account" "cloud_account" {
+  account_id = var.account_id
+  cloud_provider = "aws"
+  role_enabled = "true"
+}
+
+resource "aws_iam_role" "cloudbench_role" {
+  name = "SysdigCloudBenchRole"
+  assume_role_policy = data.aws_iam_policy_document.trust_relationship.json
+  tags = var.tags
+}
+
+data "sysdig_cloud_bench_user" "trusted_sysdig_role" {
+  sysdig_secure_endpoint = var.sysdig_secure_endpoint
+
+  // TODO this should come from the provider based on the secure URL.
+  arn = "arn:aws:iam::059797578166:user/noah.kraemer"
+}
+
+data "aws_iam_policy_document" "trust_relationship" {
+  statement {
+    effect = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type = "AWS"
+      identifiers = [data.sysdig_cloud_bench_user.trusted_sysdig_role.arn]
+    }
+    condition {
+      test = "StringEquals"
+      variable = "sts:ExternalId"
+      values = [sysdig_secure_cloud_account.cloud_account.external_id]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "cloudbench_permissions" {
+  name = "SysdigCloudBenchPolicy"
+  role = aws_iam_role.cloudbench_role.id
+  policy = data.aws_iam_policy_document.permissions.json
+}
+
+data "aws_iam_policy_document" "permissions" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "access-analyzer:List*",
+      "acm:List*",
+      "cloudtrail:DescribeTrails",
+      "cloudtrail:Get*",
+      "cloudwatch:Describe*",
+      "cloudwatch:PutMetricData",
+      "config:Describe*",
+      "ec2:CreateNetworkInterface",
+      "ec2:DeleteNetworkInterface",
+      "ec2:Describe*",
+      "elasticloadbalancing:DescribeLoadBalancers",
+      "events:PutRule",
+      "events:PutTargets",
+      "iam:DeleteAccessKey",
+      "iam:GenerateCredentialReport",
+      "iam:Get*",
+      "iam:List*",
+      "iam:UpdateAccessKey",
+      "lambda:AddPermission",
+      "lambda:CreateAlias",
+      "lambda:CreateEventSourceMapping",
+      "lambda:CreateFunction",
+      "lambda:DeleteAlias",
+      "lambda:DeleteEventSourceMapping",
+      "lambda:DeleteFunction",
+      "lambda:DeleteFunctionConcurrency",
+      "lambda:InvokeFunction",
+      "lambda:PutFunctionConcurrency",
+      "lambda:RemovePermission",
+      "lambda:TagResource",
+      "lambda:UntagResource",
+      "lambda:UpdateAlias",
+      "lambda:UpdateEventSourceMapping",
+      "lambda:UpdateFunctionCode",
+      "lambda:UpdateFunctionConfiguration",
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:Describe*",
+      "kms:ListAliases",
+      "kms:ListKeys",
+      "kms:DescribeKey",
+      "kms:GetKeyRotationStatus",
+      "s3:Get*",
+      "s3:Head*",
+      "s3:List*",
+      "s3:Put*",
+      "sns:ListSubscriptionsByTopic",
+      "tag:GetResources"
+    ]
+    resources = ["*"]
+  }
+}

--- a/modules/services/cloud-bench/main.tf
+++ b/modules/services/cloud-bench/main.tf
@@ -1,13 +1,13 @@
 resource "sysdig_secure_cloud_account" "cloud_account" {
-  account_id = var.account_id
+  account_id     = var.account_id
   cloud_provider = "aws"
-  role_enabled = "true"
+  role_enabled   = "true"
 }
 
 resource "aws_iam_role" "cloudbench_role" {
-  name = "SysdigCloudBench"
+  name               = "SysdigCloudBench"
   assume_role_policy = data.aws_iam_policy_document.trust_relationship.json
-  tags = var.tags
+  tags               = var.tags
 }
 
 data "sysdig_secure_trusted_cloud_identity" "trusted_sysdig_role" {
@@ -16,25 +16,25 @@ data "sysdig_secure_trusted_cloud_identity" "trusted_sysdig_role" {
 
 data "aws_iam_policy_document" "trust_relationship" {
   statement {
-    effect = "Allow"
+    effect  = "Allow"
     actions = ["sts:AssumeRole"]
     principals {
-      type = "AWS"
+      type        = "AWS"
       identifiers = [data.sysdig_secure_trusted_cloud_identity.trusted_sysdig_role.identity]
     }
     condition {
-      test = "StringEquals"
+      test     = "StringEquals"
       variable = "sts:ExternalId"
-      values = [sysdig_secure_cloud_account.cloud_account.external_id]
+      values   = [sysdig_secure_cloud_account.cloud_account.external_id]
     }
   }
 }
 
 resource "aws_iam_role_policy_attachment" "cloudbench_security_audit" {
-  role = aws_iam_role.cloudbench_role.id
-  policy_arn = data.aws_iam_policy.SecurityAudit.arn
+  role       = aws_iam_role.cloudbench_role.id
+  policy_arn = data.aws_iam_policy.security_audit.arn
 }
 
-data "aws_iam_policy" "SecurityAudit" {
+data "aws_iam_policy" "security_audit" {
   arn = "arn:aws:iam::aws:policy/SecurityAudit"
 }

--- a/modules/services/cloud-bench/main.tf
+++ b/modules/services/cloud-bench/main.tf
@@ -10,11 +10,7 @@ resource "aws_iam_role" "cloudbench_role" {
   tags = var.tags
 }
 
-data "sysdig_secure_cloud_bench_user" "trusted_sysdig_role" {
-  sysdig_secure_endpoint = var.sysdig_secure_endpoint
-
-  // TODO this should come from the provider based on the secure URL.
-  arn = "arn:aws:iam::059797578166:user/noah.kraemer"
+data "sysdig_secure_trusted_cloud_user" "trusted_sysdig_role" {
 }
 
 data "aws_iam_policy_document" "trust_relationship" {
@@ -23,7 +19,7 @@ data "aws_iam_policy_document" "trust_relationship" {
     actions = ["sts:AssumeRole"]
     principals {
       type = "AWS"
-      identifiers = [data.sysdig_secure_cloud_bench_user.trusted_sysdig_role.arn]
+      identifiers = [data.sysdig_secure_trusted_cloud_user.trusted_sysdig_role.arn]
     }
     condition {
       test = "StringEquals"

--- a/modules/services/cloud-bench/main.tf
+++ b/modules/services/cloud-bench/main.tf
@@ -10,7 +10,7 @@ resource "aws_iam_role" "cloudbench_role" {
   tags = var.tags
 }
 
-data "sysdig_cloud_bench_user" "trusted_sysdig_role" {
+data "sysdig_secure_cloud_bench_user" "trusted_sysdig_role" {
   sysdig_secure_endpoint = var.sysdig_secure_endpoint
 
   // TODO this should come from the provider based on the secure URL.
@@ -23,7 +23,7 @@ data "aws_iam_policy_document" "trust_relationship" {
     actions = ["sts:AssumeRole"]
     principals {
       type = "AWS"
-      identifiers = [data.sysdig_cloud_bench_user.trusted_sysdig_role.arn]
+      identifiers = [data.sysdig_secure_cloud_bench_user.trusted_sysdig_role.arn]
     }
     condition {
       test = "StringEquals"
@@ -33,65 +33,11 @@ data "aws_iam_policy_document" "trust_relationship" {
   }
 }
 
-resource "aws_iam_role_policy" "cloudbench_permissions" {
-  name = "SysdigCloudBenchPolicy"
+resource "aws_iam_role_policy_attachment" "cloudbench_security_audit" {
   role = aws_iam_role.cloudbench_role.id
-  policy = data.aws_iam_policy_document.permissions.json
+  policy_arn = data.aws_iam_policy.SecurityAudit.arn
 }
 
-data "aws_iam_policy_document" "permissions" {
-  statement {
-    effect = "Allow"
-    actions = [
-      "access-analyzer:List*",
-      "acm:List*",
-      "cloudtrail:DescribeTrails",
-      "cloudtrail:Get*",
-      "cloudwatch:Describe*",
-      "cloudwatch:PutMetricData",
-      "config:Describe*",
-      "ec2:CreateNetworkInterface",
-      "ec2:DeleteNetworkInterface",
-      "ec2:Describe*",
-      "elasticloadbalancing:DescribeLoadBalancers",
-      "events:PutRule",
-      "events:PutTargets",
-      "iam:DeleteAccessKey",
-      "iam:GenerateCredentialReport",
-      "iam:Get*",
-      "iam:List*",
-      "iam:UpdateAccessKey",
-      "lambda:AddPermission",
-      "lambda:CreateAlias",
-      "lambda:CreateEventSourceMapping",
-      "lambda:CreateFunction",
-      "lambda:DeleteAlias",
-      "lambda:DeleteEventSourceMapping",
-      "lambda:DeleteFunction",
-      "lambda:DeleteFunctionConcurrency",
-      "lambda:InvokeFunction",
-      "lambda:PutFunctionConcurrency",
-      "lambda:RemovePermission",
-      "lambda:TagResource",
-      "lambda:UntagResource",
-      "lambda:UpdateAlias",
-      "lambda:UpdateEventSourceMapping",
-      "lambda:UpdateFunctionCode",
-      "lambda:UpdateFunctionConfiguration",
-      "logs:CreateLogGroup",
-      "logs:CreateLogStream",
-      "logs:Describe*",
-      "kms:ListAliases",
-      "kms:ListKeys",
-      "kms:DescribeKey",
-      "kms:GetKeyRotationStatus",
-      "s3:Get*",
-      "s3:Head*",
-      "s3:List*",
-      "s3:Put*",
-      "sns:ListSubscriptionsByTopic",
-      "tag:GetResources"
-    ]
-    resources = ["*"]
-  }
+data "aws_iam_policy" "SecurityAudit" {
+  arn = "arn:aws:iam::aws:policy/SecurityAudit"
 }

--- a/modules/services/cloud-bench/main.tf
+++ b/modules/services/cloud-bench/main.tf
@@ -11,6 +11,7 @@ resource "aws_iam_role" "cloudbench_role" {
 }
 
 data "sysdig_secure_trusted_cloud_user" "trusted_sysdig_role" {
+  cloud_provider = "aws"
 }
 
 data "aws_iam_policy_document" "trust_relationship" {

--- a/modules/services/cloud-bench/main.tf
+++ b/modules/services/cloud-bench/main.tf
@@ -5,12 +5,12 @@ resource "sysdig_secure_cloud_account" "cloud_account" {
 }
 
 resource "aws_iam_role" "cloudbench_role" {
-  name = "SysdigCloudBenchRole"
+  name = "SysdigCloudBench"
   assume_role_policy = data.aws_iam_policy_document.trust_relationship.json
   tags = var.tags
 }
 
-data "sysdig_secure_trusted_cloud_user" "trusted_sysdig_role" {
+data "sysdig_secure_trusted_cloud_identity" "trusted_sysdig_role" {
   cloud_provider = "aws"
 }
 
@@ -20,7 +20,7 @@ data "aws_iam_policy_document" "trust_relationship" {
     actions = ["sts:AssumeRole"]
     principals {
       type = "AWS"
-      identifiers = [data.sysdig_secure_trusted_cloud_user.trusted_sysdig_role.arn]
+      identifiers = [data.sysdig_secure_trusted_cloud_identity.trusted_sysdig_role.identity]
     }
     condition {
       test = "StringEquals"

--- a/modules/services/cloud-bench/variables.tf
+++ b/modules/services/cloud-bench/variables.tf
@@ -7,12 +7,6 @@ variable "account_id" {
 # optionals - with default
 #---------------------------------
 
-variable "sysdig_secure_endpoint" {
-  type        = string
-  default     = "https://secure.sysdig.com"
-  description = "Sysdig Secure API endpoint"
-}
-
 variable "tags" {
   type        = map(string)
   description = "sysdig cloudvision tags"

--- a/modules/services/cloud-bench/variables.tf
+++ b/modules/services/cloud-bench/variables.tf
@@ -1,0 +1,22 @@
+variable "account_id" {
+  type        = string
+  description = "the account_id in which to provision the cloud-bench IAM role"
+}
+
+#---------------------------------
+# optionals - with default
+#---------------------------------
+
+variable "sysdig_secure_endpoint" {
+  type        = string
+  default     = "https://secure.sysdig.com"
+  description = "Sysdig Secure API endpoint"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "sysdig cloudvision tags"
+  default = {
+    "product" = "sysdig-cloudvision"
+  }
+}

--- a/modules/services/cloud-bench/versions.tf
+++ b/modules/services/cloud-bench/versions.tf
@@ -5,7 +5,7 @@ terraform {
       version = ">= 3.50.0"
     }
     sysdig = {
-      source = "sysdiglabs/sysdig"
+      source  = "sysdiglabs/sysdig"
       version = ">= 0.5.17"
     }
   }

--- a/modules/services/cloud-bench/versions.tf
+++ b/modules/services/cloud-bench/versions.tf
@@ -2,8 +2,7 @@ terraform {
   required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      version               = ">= 3.50.0"
-      configuration_aliases = [aws.cloudvision]
+      version = ">= 3.50.0"
     }
     sysdig = {
       source = "sysdiglabs/sysdig"

--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
       configuration_aliases = [aws.cloudvision]
     }
     sysdig = {
-      source = "sysdiglabs/sysdig"
+      source  = "sysdiglabs/sysdig"
       version = ">= 0.5.17"
     }
   }


### PR DESCRIPTION
Replaces #6 to avoid a messy rebase. 

Also addresses the comments, namely:
- Switching to only onboarding a single cloud bench account
- Using AssumeRole from the org account to provision into the target member account
- Sourcing the trusted role ARN from the sysdig-provider (Requires https://github.com/sysdiglabs/terraform-provider-sysdig/pull/113)
- Adds README