### PR TITLE
fix: name collision on concurrent usage

### DIFF
--- a/examples/organizational/main.tf
+++ b/examples/organizational/main.tf
@@ -31,4 +31,6 @@ module "cloudvision" {
   #  (optional) testing purpose; economization
   cloudtrail_org_is_multi_region_trail = false
   cloudtrail_org_kms_enable            = false
+
+  tags = var.tags
 }

--- a/examples/single-account/README.md
+++ b/examples/single-account/README.md
@@ -76,6 +76,7 @@ No resources.
 | <a name="input_name"></a> [name](#input\_name) | Name to be assigned to all child resources | `string` | `"sysdig-cloudvision"` | no |
 | <a name="input_region"></a> [region](#input\_region) | Default region for resource creation in the account | `string` | `"eu-central-1"` | no |
 | <a name="input_sysdig_secure_endpoint"></a> [sysdig\_secure\_endpoint](#input\_sysdig\_secure\_endpoint) | Sysdig Secure API endpoint | `string` | `"https://secure.sysdig.com"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | sysdig cloudvision tags | `map(string)` | <pre>{<br>  "product": "sysdig-cloudvision"<br>}</pre> | no |
 
 ## Outputs
 

--- a/examples/single-account/main.tf
+++ b/examples/single-account/main.tf
@@ -8,11 +8,14 @@ module "cloudvision" {
   providers = {
     aws.cloudvision = aws
   }
-  name                    = var.name
+  name = var.name
+
   sysdig_secure_endpoint  = var.sysdig_secure_endpoint
   sysdig_secure_api_token = var.sysdig_secure_api_token
 
   #  (optional) testing purpose; economization
   cloudtrail_org_is_multi_region_trail = false
   cloudtrail_org_kms_enable            = false
+
+  tags = var.tags
 }

--- a/examples/single-account/variables.tf
+++ b/examples/single-account/variables.tf
@@ -26,3 +26,11 @@ variable "sysdig_secure_endpoint" {
   default     = "https://secure.sysdig.com"
   description = "Sysdig Secure API endpoint"
 }
+
+variable "tags" {
+  type        = map(string)
+  description = "sysdig cloudvision tags"
+  default = {
+    "product" = "sysdig-cloudvision"
+  }
+}

--- a/modules/infrastructure/organizational/cloudvision-role/main.tf
+++ b/modules/infrastructure/organizational/cloudvision-role/main.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "cloudvision_role" {
-  name               = "SysdigCloudVisionRole"
+  name               = "${var.name}-SysdigCloudVisionRole"
   assume_role_policy = data.aws_iam_policy_document.cloudvision_role_trusted.json
   tags               = var.tags
 }
@@ -58,7 +58,7 @@ data "aws_iam_policy_document" "enable_assume_cloudvision_role" {
 # ------------------------------
 
 resource "aws_iam_role_policy" "cloudvision_role_s3" {
-  name   = "AllowCloudtrailS3Policy"
+  name   = "${var.name}-AllowCloudtrailS3Policy"
   role   = aws_iam_role.cloudvision_role.id
   policy = data.aws_iam_policy_document.cloudvision_role_s3.json
 }

--- a/modules/services/cloud-connector/cloudwatch.tf
+++ b/modules/services/cloud-connector/cloudwatch.tf
@@ -5,6 +5,6 @@ resource "aws_cloudwatch_log_group" "log" {
 }
 
 resource "aws_cloudwatch_log_stream" "stream" {
-  name           = "alerts"
+  name           = "${var.name}-alerts"
   log_group_name = aws_cloudwatch_log_group.log.name
 }

--- a/modules/services/cloud-connector/ecs-service.tf
+++ b/modules/services/cloud-connector/ecs-service.tf
@@ -19,7 +19,7 @@ resource "aws_ecs_service" "service" {
 
 
 resource "aws_ecs_task_definition" "task_definition" {
-  family                   = "cloud_connector"
+  family                   = "${var.name}-cloud_connector"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
   execution_role_arn       = aws_iam_role.execution.arn # ARN of the task execution role that the Amazon ECS container agent and the Docker daemon can assume


### PR DESCRIPTION
`var.name` usage on top examples + inheritance to avoid multiple-user testing on same org